### PR TITLE
Proper link for Localizer

### DIFF
--- a/_collections/_collaborators/localizer.md
+++ b/_collections/_collaborators/localizer.md
@@ -3,7 +3,7 @@ name: Localizer
 subcat: study
 contact:
 avatar: neurospin.png
-ext_url: http://brainomics.cea.fr/localizer/localizer
+ext_url: https://doi.org/10.25720/1ca1-0sfd
 joined: 2021
 ---
 


### PR DESCRIPTION
The `brainomics.cea.fr` is not the proper link, use the DOI instead.

Also, the license in [IEEEDataPort](https://ieee-dataport.org/open-access/openbhb-multi-site-brain-mri-dataset-age-prediction-and-debiasing) is incorrect:
* **Localizer** [11] Licence term CC BY 3.0

It is "[_Attribution-NonCommercial 4.0 International_](https://creativecommons.org/licenses/by-nc/4.0/)" so please change it into:
* **Localizer** [11] Licence term CC BY-NC 4.0

Also, please fix the citation on that same page: the main author is `Papadopoulos Orfanos, D.`, not `Orfanos, D. P.`.
